### PR TITLE
Add undo-tree-window-side for better window-placement

### DIFF
--- a/undo-tree.el
+++ b/undo-tree.el
@@ -932,6 +932,10 @@ enabled. However, this effect is quite rare in practice."
 		 (const :tag "always" t)
 		 (integer :tag "> size")))
 
+(defcustom undo-tree-window-side nil
+  "The undo-tree window pops up on this side."
+  :type '(choice (const :tag "Bottom" bottom)
+                 (const :tag "Top"    top)))
 
 (defvar undo-tree-pre-save-element-functions '()
   "Special hook to modify undo-tree elements prior to saving.
@@ -3423,8 +3427,14 @@ Note this will overwrite any existing undo history."
   (let ((undo-tree buffer-undo-tree)
         (buff (current-buffer))
 	(display-buffer-mark-dedicated 'soft))
-    (switch-to-buffer-other-window
-     (get-buffer-create undo-tree-visualizer-buffer-name))
+    (if undo-tree-window-side
+	(select-window
+	 (display-buffer-in-side-window
+	  (get-buffer-create undo-tree-visualizer-buffer-name)
+	  `((side . ,undo-tree-window-side)
+            (window-height . 10))))
+      (switch-to-buffer-other-window
+       (get-buffer-create undo-tree-visualizer-buffer-name)))
     (setq undo-tree-visualizer-parent-buffer buff)
     (setq undo-tree-visualizer-parent-mtime
 	  (and (buffer-file-name buff)


### PR DESCRIPTION
I saw [vundo ](https://github.com/casouri/vundo) an found it has a better window placement because it's "fixed". In standard undo-tree behaivior it is relative to the current buffer.

I would introduce a custom variable which imitate the behaivior of vundo. Nothing would change if this custom variable isn't touched.

See changes ❤️ 